### PR TITLE
Memory leak partially fixed

### DIFF
--- a/src/EE895.cpp
+++ b/src/EE895.cpp
@@ -139,6 +139,7 @@ float EE895::readRegisterFloat(uint16_t address) {
   } value;
 
   uint8_t *registerContents = readRegister(address, 2);
+
   if (registerContents == NULL) {
     return NAN;
   }
@@ -147,6 +148,8 @@ float EE895::readRegisterFloat(uint16_t address) {
   value.b[0] = registerContents[1];
   value.b[3] = registerContents[2];
   value.b[2] = registerContents[3];
+
+  delete[] registerContents;
 
   return value.f;
 }


### PR DESCRIPTION
Memory leak partially fixed for all functions based on "float readRegisterFloat(uint16_t address)":

* getCO2Average()
* getTemperatureInDegreeC()
* getTemperatureInDegreeF()
* getTemperatureInK()
* getCO2Raw()
* getPressureInmbar()
* getPressureInpsi()

Note: For other functions that are not based on "float readRegisterFloat(uint16_t address)", the memory leak is still present and should be fixed.